### PR TITLE
Add a paramter to specify a log file to list missing variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: iamc
 Type: Package
 Title: IAMC Tools
-Version: 0.26.0
-Date: 2019-12-13
+Version: 0.27.0
+Date: 2020-06-09
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = "aut"),
              person("Cornelia", "Auer", email = "cornelia.auer@pik-potsdam.de", role = "aut"))
@@ -22,8 +22,8 @@ Imports: quitte(>= 0.3066),
          writexl
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Suggests: knitr,
           rmarkdown
 VignetteBuilder: knitr
-ValidationKey: 4743180
+ValidationKey: 4973940

--- a/R/write.reportProject.R
+++ b/R/write.reportProject.R
@@ -28,6 +28,7 @@
 #' @param max_file_size maximum file size in MB; if size of file exceeds max_file_size reporting is split into multiple files
 #' @param format available reporting formats: "default", "IAMC" and "AgMIP". "default" and "IAMC" are very similar (wide format for year) and differ only in the use of semi-colon (default) and comma (IAMC) as seperator. "AgMIP" is in long format.
 #' @param append Logical which decides whether data should be added to an existing file or an existing file should be overwritten
+#' @param missing_log name of logfile to record variables which are present in the mapping but missing in the mif file. By default, no logfile is produced
 #' @param ... arguments passed to write.report and write.report2
 #' @author Christoph Bertram, Lavinia Baumstark, Anastasis Giannousakis, Florian Humpenoeder
 #' @seealso \code{\link{write.report}}
@@ -45,7 +46,9 @@
 #' @importFrom writexl write_xlsx
 #' @export
 
-write.reportProject <- function(mif,mapping,file=NULL,max_file_size=NULL,format="default",append=FALSE,...){
+write.reportProject <- function(mif, mapping,
+                                file=NULL, max_file_size=NULL,
+                                format="default", append=FALSE, missing_log=NULL, ...){
   if(is.character(mif)){
     data <- read.report(mif,as.list=TRUE)
   } else if (is.list(mif)){
@@ -170,7 +173,15 @@ write.reportProject <- function(mif,mapping,file=NULL,max_file_size=NULL,format=
     }
   }
 
-  if (length(missingc) !=0) warning(paste0("Following variables were not found in the generic data and were excluded: \"",paste(unique(missingc),collapse = "\", \""),"\""))
+  if (length(missingc) !=0){
+    warning(
+      paste0(
+        "Following variables were not found in the generic data and were excluded: \"",
+        paste(unique(missingc), collapse = "\", \""),"\""))
+    if (!is.null(missing_log)){
+      write(c(sprintf("#--- Variables missing in %s ---#", mif), missingc, "\n"), missing_log, append=TRUE)
+    }
+  }
 
   if(!is.null(file)){
     # save project reporting

--- a/man/write.reportProject.Rd
+++ b/man/write.reportProject.Rd
@@ -11,6 +11,7 @@ write.reportProject(
   max_file_size = NULL,
   format = "default",
   append = FALSE,
+  missing_log = NULL,
   ...
 )
 }
@@ -41,6 +42,8 @@ Unit is a name of the unit without ()
 \item{format}{available reporting formats: "default", "IAMC" and "AgMIP". "default" and "IAMC" are very similar (wide format for year) and differ only in the use of semi-colon (default) and comma (IAMC) as seperator. "AgMIP" is in long format.}
 
 \item{append}{Logical which decides whether data should be added to an existing file or an existing file should be overwritten}
+
+\item{missing_log}{name of logfile to record variables which are present in the mapping but missing in the mif file. By default, no logfile is produced}
 
 \item{...}{arguments passed to write.report and write.report2}
 }


### PR DESCRIPTION
If a lot of variables are missing in the MIF file, the warning produced by R is truncated within most environments by default. Since it is quite important to check which variables are missing in the output (but present in the mapping), I added a parameter to the `write.reportProject` function which allows the specification of a log file for missing variables.

The variables are appended to the log file.