### PR TITLE
If missing variables are written to a log file, no warning is produced.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: iamc
 Type: Package
 Title: IAMC Tools
-Version: 0.27.0
-Date: 2020-06-09
+Version: 0.27.1
+Date: 2020-06-12
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = "aut"),
              person("Cornelia", "Auer", email = "cornelia.auer@pik-potsdam.de", role = "aut"))
@@ -26,4 +26,4 @@ RoxygenNote: 7.1.0
 Suggests: knitr,
           rmarkdown
 VignetteBuilder: knitr
-ValidationKey: 4973940
+ValidationKey: 4993175

--- a/R/write.reportProject.R
+++ b/R/write.reportProject.R
@@ -174,11 +174,12 @@ write.reportProject <- function(mif, mapping,
   }
 
   if (length(missingc) !=0){
-    warning(
-      paste0(
-        "Following variables were not found in the generic data and were excluded: \"",
-        paste(unique(missingc), collapse = "\", \""),"\""))
-    if (!is.null(missing_log)){
+    if (is.null(missing_log)){
+      warning(
+        paste0(
+          "Following variables were not found in the generic data and were excluded: \"",
+          paste(unique(missingc), collapse = "\", \""),"\""))
+    }else{
       write(c(sprintf("#--- Variables missing in %s ---#", mif), missingc, "\n"), missing_log, append=TRUE)
     }
   }


### PR DESCRIPTION
This is related to the last PR #3 
Warnings related to missing variables are no longer written to the output if a log files is specified, rendering the remaining warnings useful.