### PR TITLE
temp bugfix for helperbounds not handling ref data correctly

### DIFF
--- a/R/helperBounds.R
+++ b/R/helperBounds.R
@@ -1,5 +1,7 @@
 helperBounds <- function(x, cfg, type) {
-  x$ref <- cfg[[type]][x$variable]
+  for (i in levels(x$variable)) {
+    x[which(x$variable == i), "ref"] <- cfg[[type]][which(cfg$variable == i)]
+  }
   if(type=="min") {
     x$check <- (x$value>=x$ref)
   } else if(type=="max") {


### PR DESCRIPTION
`checkMin` and `checkMax` tests have been wrong all this time due to this line:
https://github.com/IAMconsortium/iamc/blob/c4849cfc75997699d5e31d492ddf9021f3dad816/R/helperBounds.R#L2
Here's a suggested quickfix.